### PR TITLE
Remove Agency Dashboard label from header

### DIFF
--- a/RealEstateCRMWinForms/Views/MainView.cs
+++ b/RealEstateCRMWinForms/Views/MainView.cs
@@ -704,11 +704,10 @@ namespace RealEstateCRMWinForms.Views
             {
                 section = "Dashboard";
             }
-            // Show "Agency Dashboard" in the small top header when Dashboard is active,
-            // otherwise show the section name as-is.
-            // Title logic: Dashboard uses "Agency Dashboard", others use section name
+            // Update the small top header. For Dashboard we no longer show "Agency Dashboard";
+            // leave it blank instead. Other sections continue to use their section name.
             var effectiveTitle = section;
-            lblSectionTitle.Text = effectiveTitle == "Dashboard" ? "Agency Dashboard" : effectiveTitle;
+            lblSectionTitle.Text = effectiveTitle == "Dashboard" ? string.Empty : effectiveTitle;
 
             // set visual active button and update content
             switch (section)


### PR DESCRIPTION
## Summary
- stop overriding the dashboard header text with "Agency Dashboard"
- leave the header blank when the Dashboard section is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da66482f98832abcae2addb0b7962a